### PR TITLE
allow the result of compression to be larger than the original

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,6 @@ pub fn compress(indata: &[u8]) -> Result<Vec<u8>, Error> {
             wrkmem.as_mut_ptr() as *mut _);
 
         if r == 0 {
-            if outlen > inlen {
-                return Err(Error::NotCompressible)
-            }
-
             outdata.set_len(outlen);
             return Ok(outdata)
         }
@@ -179,8 +175,14 @@ fn init() {
 }
 
 #[test]
-fn test_compress_skips_short() {
-    assert_eq!(Err(Error::NotCompressible), compress("foo".as_bytes()));
+fn test_compress_short() {
+let data = "foo".as_bytes();
+    let compressed = compress(data).unwrap();
+    assert_eq!(compressed.len(), 7);
+
+    let decompressed = decompress(&compressed, 3).unwrap();
+    assert_eq!(decompressed.len(), 3);
+    assert_eq!(decompressed, data);
 }
 
 #[test]


### PR DESCRIPTION
While unfortunate it is true that for some inputs LZO will produce a
larger output than the original.  This is especially likely to happen
for random bytes, or already compressed data, but in theory it can
happen for any other input.  In anycase some protocols and formats
require the data be LZO compressed even if uncompressed would be
smaller.  As such its necessary to return the compressed buffer even if
it is larger than the input.  Some consumers may choose to not use the
result if it is larger, but that choice belongs in the consumer, not a
wrapper around liblzo.